### PR TITLE
Add `SolvingError` type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ clap = {version = "4", features = ["derive"]}
 log = {version = "0.4", features = ["release_max_level_info"]}
 simple_logger = {version = "4", features = ["colors", "stderr", "timestamps"]}
 time = "0.3"
+duration-human = "0.1"
 
 
 [dev-dependencies]

--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -15,6 +15,7 @@ pub enum BoardMove {
 }
 
 impl BoardMove {
+    #[must_use]
     pub fn opposite(&self) -> Self {
         match self {
             BoardMove::Up => BoardMove::Down,
@@ -52,6 +53,6 @@ pub trait Board {
 
     /// # Panics
     /// This function may panic if the move cannot be performed.
-    /// To avoid it, check before if a move can be executed using [can_move](Board::can_move)
+    /// To avoid it, check before if a move can be executed using [`can_move`](Board::can_move)
     fn exec_move(&mut self, board_move: BoardMove);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,11 +155,14 @@ fn main() {
     let solver = create_solver(cli.algorithm_info, board);
     log::info!("Starting solver");
 
-    let start = time::Instant::now();
+    let start = std::time::Instant::now();
     let result = solver.solve();
     let finish = start.elapsed();
     if result.is_ok() {
-        log::info!("Found solution in {:.3}s", finish.as_seconds_f64())
+        log::info!(
+            "Found solution in {:#}",
+            duration_human::DurationHuman::from(finish)
+        )
     }
     let solution = result.unwrap_or_else(|_| {
         log::warn!("Board is unsolvable");

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,6 +177,9 @@ fn main() {
     };
 
     println!("{}", solution.len());
-    let solution_str: Vec<_> = solution.iter().map(|x| x.to_string()).collect();
+    let solution_str: Vec<_> = solution
+        .iter()
+        .map(std::string::ToString::to_string)
+        .collect();
     println!("{}", solution_str.join(""));
 }

--- a/src/solving/algorithm/astar.rs
+++ b/src/solving/algorithm/astar.rs
@@ -95,6 +95,7 @@ fn undo_move_sequence(
 }
 
 impl AStarSolver {
+    #[must_use]
     pub fn new(board: OwnedBoard, heuristic: Box<dyn Heuristic>) -> Self {
         let mut queue = BinaryHeap::new();
         let heuristic: Rc<dyn Heuristic> = Rc::from(heuristic);
@@ -103,7 +104,7 @@ impl AStarSolver {
                 board,
                 path: vec![],
                 heuristic: Rc::clone(&heuristic),
-            })
+            });
         }
 
         Self {
@@ -167,6 +168,7 @@ enum IDAStarResult {
 }
 
 impl IterativeAStarSolver {
+    #[must_use]
     pub fn new(board: OwnedBoard, heuristic: Box<dyn Heuristic>) -> Self {
         Self {
             board,
@@ -201,7 +203,7 @@ impl IterativeAStarSolver {
                 }
                 (_, _) => {}
             }
-            undo_move_sequence(&mut self.board, &mut self.path, next_move)
+            undo_move_sequence(&mut self.board, &mut self.path, next_move);
         }
         minimum.map_or(IDAStarResult::NotFound, IDAStarResult::Exceeded)
     }

--- a/src/solving/algorithm/astar.rs
+++ b/src/solving/algorithm/astar.rs
@@ -3,7 +3,7 @@ use std::collections::BinaryHeap;
 use std::rc::Rc;
 
 use crate::board::{Board, BoardMove, OwnedBoard};
-use crate::solving::algorithm::Solver;
+use crate::solving::algorithm::{Solver, SolvingError};
 use crate::solving::is_solvable;
 use crate::solving::movegen::{MoveGenerator, MoveSequence};
 
@@ -137,7 +137,7 @@ impl AStarSolver {
 }
 
 impl Solver for AStarSolver {
-    fn solve(mut self: Box<Self>) -> Result<Vec<BoardMove>, ()> {
+    fn solve(mut self: Box<Self>) -> Result<Vec<BoardMove>, SolvingError> {
         let mut max_f_cost = 0;
         while let Some(node) = self.queue.pop() {
             let f_cost = node.f_cost();
@@ -149,7 +149,7 @@ impl Solver for AStarSolver {
                 return Ok(result);
             }
         }
-        Err(())
+        Err(SolvingError::UnsolvableBoard)
     }
 }
 
@@ -208,9 +208,9 @@ impl IterativeAStarSolver {
 }
 
 impl Solver for IterativeAStarSolver {
-    fn solve(mut self: Box<Self>) -> Result<Vec<BoardMove>, ()> {
+    fn solve(mut self: Box<Self>) -> Result<Vec<BoardMove>, SolvingError> {
         if !is_solvable(&self.board) {
-            return Err(());
+            return Err(SolvingError::UnsolvableBoard);
         }
         let mut bound = self.heuristic.evaluate(&self.board);
         loop {

--- a/src/solving/algorithm/bfs.rs
+++ b/src/solving/algorithm/bfs.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashSet, VecDeque};
 
 use crate::board::{Board, BoardMove, OwnedBoard};
-use crate::solving::algorithm::Solver;
+use crate::solving::algorithm::{Solver, SolvingError};
 use crate::solving::is_solvable;
 use crate::solving::movegen::{MoveGenerator, MoveSequence};
 
@@ -73,12 +73,12 @@ impl BFSSolver {
 }
 
 impl Solver for BFSSolver {
-    fn solve(mut self: Box<Self>) -> Result<Vec<BoardMove>, ()> {
+    fn solve(mut self: Box<Self>) -> Result<Vec<BoardMove>, SolvingError> {
         while let Some((board, path)) = self.queue.pop_front() {
             if let Some(result) = self.bfs_iteration(board, path) {
                 return Ok(result);
             }
         }
-        Err(())
+        Err(SolvingError::UnsolvableBoard)
     }
 }

--- a/src/solving/algorithm/bfs.rs
+++ b/src/solving/algorithm/bfs.rs
@@ -12,10 +12,11 @@ pub struct BFSSolver {
 }
 
 impl BFSSolver {
+    #[must_use]
     pub fn new(board: OwnedBoard, move_generator: MoveGenerator) -> Self {
         let mut queue = VecDeque::new();
         if is_solvable(&board) {
-            queue.push_back((board, vec![]))
+            queue.push_back((board, vec![]));
         }
         Self {
             visited: HashSet::new(),

--- a/src/solving/algorithm/dfs.rs
+++ b/src/solving/algorithm/dfs.rs
@@ -45,6 +45,7 @@ impl From<DFSError> for SolvingError {
 }
 
 impl DFSSolver {
+    #[must_use]
     pub fn new(board: OwnedBoard, move_generator: MoveGenerator) -> Self {
         Self {
             board,
@@ -161,6 +162,7 @@ pub struct IncrementalDFSSolver {
 }
 
 impl IncrementalDFSSolver {
+    #[must_use]
     pub fn new(board: OwnedBoard, move_generator: MoveGenerator) -> Self {
         Self {
             dfs_solver: DFSSolver::new(board, move_generator),

--- a/src/solving/algorithm/dfs.rs
+++ b/src/solving/algorithm/dfs.rs
@@ -1,7 +1,8 @@
 use std::collections::HashSet;
+use std::fmt::{Display, Formatter};
 
 use crate::board::{Board, BoardMove, OwnedBoard};
-use crate::solving::algorithm::Solver;
+use crate::solving::algorithm::{Solver, SolvingError};
 use crate::solving::is_solvable;
 use crate::solving::movegen::{MoveGenerator, MoveSequence};
 
@@ -10,6 +11,37 @@ pub struct DFSSolver {
     move_generator: MoveGenerator,
     current_path: Vec<BoardMove>,
     board: OwnedBoard,
+}
+
+#[derive(Debug)]
+enum DFSError {
+    /// Solver visits the state it has already visited before
+    StateAlreadyVisited,
+    /// Solver reached max depth of the search tree
+    MaxDepthReached,
+    /// All of the moves possible from this position yielded an error
+    StateExhausted,
+}
+
+impl Display for DFSError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DFSError::StateAlreadyVisited => write!(f, "Solver has already visited this state"),
+            DFSError::MaxDepthReached => write!(f, "Solver reached max depth of the search tree"),
+            DFSError::StateExhausted => write!(
+                f,
+                "None of the moves from this position results in a solution"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for DFSError {}
+
+impl From<DFSError> for SolvingError {
+    fn from(value: DFSError) -> Self {
+        Self::AlgorithmError(Box::new(value))
+    }
 }
 
 impl DFSSolver {
@@ -26,18 +58,18 @@ impl DFSSolver {
         &mut self,
         current_depth: usize,
         max_depth: Option<usize>,
-    ) -> Result<(), ()> {
+    ) -> Result<(), DFSError> {
         if self.board.is_solved() {
             return Ok(());
         }
         if self.visited.contains(&self.board) {
-            return Err(());
+            return Err(DFSError::StateAlreadyVisited);
         }
         self.visited.insert(self.board.clone());
 
         if let Some(max_depth) = max_depth {
             if current_depth >= max_depth {
-                return Err(());
+                return Err(DFSError::MaxDepthReached);
             }
         }
 
@@ -52,25 +84,21 @@ impl DFSSolver {
             self.undo_move_sequence(&next_move);
         }
 
-        Err(())
+        Err(DFSError::StateExhausted)
     }
 
     fn _call_recursive(
         &mut self,
         current_depth: usize,
         max_depth: Option<usize>,
-    ) -> Result<(), ()> {
+    ) -> Result<(), DFSError> {
         const STACK_RED_ZONE: usize = 64 * 1024;
         #[cfg(feature = "stack-expansion")]
         {
             // If we have less than `STACK_RED_ZONE` stack remaining, we allocate 4MB for a new stack
-            if stacker::maybe_grow(STACK_RED_ZONE, 4 * 1024 * 1024, || {
+            stacker::maybe_grow(STACK_RED_ZONE, 4 * 1024 * 1024, || {
                 self.perform_iteration(current_depth + 1, max_depth)
             })
-            .is_ok()
-            {
-                return Ok(());
-            }
         }
         #[cfg(not(feature = "stack-expansion"))]
         {
@@ -78,14 +106,11 @@ impl DFSSolver {
                 // If we have less than `STACK_RED_ZONE` stack remaining, we must backtrack to avoid stack overflow
                 if remaining < STACK_RED_ZONE {
                     log::debug!("DFS reached stack limit at depth {current_depth}, backtracking");
-                    return Err(());
+                    return Err(DFSError::MaxDepthReached);
                 }
             }
-            if self.perform_iteration(current_depth + 1, max_depth).is_ok() {
-                return Ok(());
-            }
+            self.perform_iteration(current_depth + 1, max_depth)
         }
-        Err(())
     }
 
     fn exec_move_sequence(&mut self, move_sequence: &MoveSequence) {
@@ -120,13 +145,12 @@ impl DFSSolver {
 }
 
 impl Solver for DFSSolver {
-    fn solve(mut self: Box<Self>) -> Result<Vec<BoardMove>, ()> {
+    fn solve(mut self: Box<Self>) -> Result<Vec<BoardMove>, SolvingError> {
         if !is_solvable(&self.board) {
-            return Err(());
+            return Err(SolvingError::UnsolvableBoard);
         }
 
-        self.perform_iteration(0, None)
-            .expect("If board is solvable, DFS without depth limit should always find a solution");
+        self.perform_iteration(0, None)?;
 
         Ok(self.current_path)
     }
@@ -145,9 +169,9 @@ impl IncrementalDFSSolver {
 }
 
 impl Solver for IncrementalDFSSolver {
-    fn solve(mut self: Box<Self>) -> Result<Vec<BoardMove>, ()> {
+    fn solve(mut self: Box<Self>) -> Result<Vec<BoardMove>, SolvingError> {
         if !is_solvable(&self.dfs_solver.board) {
-            return Err(());
+            return Err(SolvingError::UnsolvableBoard);
         }
 
         let mut max_depth = 1;

--- a/src/solving/algorithm/heuristics.rs
+++ b/src/solving/algorithm/heuristics.rs
@@ -99,7 +99,7 @@ impl Heuristic for LinearConflict {
 }
 
 /// Implementation of heuristic developed by Ken'ichiro Takahashi
-/// Description of the heuristic can be found at https://computerpuzzle.net/puzzle/15puzzle/index.html
+/// Description of the heuristic can be found at <https://computerpuzzle.net/puzzle/15puzzle/index.html>
 #[derive(Default)]
 pub struct InversionDistance {
     cache: std::cell::RefCell<Option<InversionDistanceCache>>,

--- a/src/solving/algorithm/mod.rs
+++ b/src/solving/algorithm/mod.rs
@@ -27,7 +27,7 @@ impl Display for SolvingError {
         match self {
             SolvingError::UnsolvableBoard => write!(f, "Board is unsolvable"),
             SolvingError::AlgorithmError(inner) => {
-                write!(f, "Solving error: {}", inner)
+                write!(f, "Solving error: {inner}")
             }
         }
     }

--- a/src/solving/algorithm/mod.rs
+++ b/src/solving/algorithm/mod.rs
@@ -1,3 +1,6 @@
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+
 use crate::board::BoardMove;
 
 pub mod astar;
@@ -13,6 +16,25 @@ pub mod solvers {
     pub use super::dfs::IncrementalDFSSolver;
 }
 
+#[derive(Debug)]
+pub enum SolvingError {
+    UnsolvableBoard,
+    AlgorithmError(Box<dyn Error>),
+}
+
+impl Display for SolvingError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SolvingError::UnsolvableBoard => write!(f, "Board is unsolvable"),
+            SolvingError::AlgorithmError(inner) => {
+                write!(f, "Solving error: {}", inner)
+            }
+        }
+    }
+}
+
+impl Error for SolvingError {}
+
 pub trait Solver {
-    fn solve(self: Box<Self>) -> Result<Vec<BoardMove>, ()>;
+    fn solve(self: Box<Self>) -> Result<Vec<BoardMove>, SolvingError>;
 }

--- a/src/solving/movegen.rs
+++ b/src/solving/movegen.rs
@@ -26,7 +26,7 @@ impl Display for SearchOrder {
                         BoardMove::Down => write!(f, "D"),
                         BoardMove::Left => write!(f, "L"),
                         BoardMove::Right => write!(f, "R"),
-                    }?
+                    }?;
                 }
             }
             SearchOrder::Random => write!(f, "Random")?,
@@ -47,6 +47,7 @@ impl Default for MoveGenerator {
 }
 
 impl MoveGenerator {
+    #[must_use]
     pub fn new(search_order: SearchOrder) -> Self {
         MoveGenerator { search_order }
     }
@@ -81,7 +82,7 @@ impl MoveGenerator {
             }
 
             if generate_single_move {
-                next_moves.push(MoveSequence::Single(first_move))
+                next_moves.push(MoveSequence::Single(first_move));
             } else {
                 for second_move in search_order {
                     let second_position = position_after_move(first_position, second_move);

--- a/src/solving/parity.rs
+++ b/src/solving/parity.rs
@@ -9,7 +9,7 @@ pub enum Parity {
 }
 
 impl Parity {
-    fn opposite(&self) -> Parity {
+    fn opposite(self) -> Parity {
         match self {
             Parity::Even => Parity::Odd,
             Parity::Odd => Parity::Even,


### PR DESCRIPTION
Add a specific type representing the error returned in case the solver is unable to solve the board.
This is done to enable consumers to differentiate cases where the board is not solvable, and where the solver failed for a different reason.

Additionally, the `new()` functions were annotated with the `[must_use]` attribute and semicolons were added for unit expressions for consistent formatting.